### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/REST_UBER/sam_rest/sam_callable.py
+++ b/REST_UBER/sam_rest/sam_callable.py
@@ -50,7 +50,7 @@ def mongo_motor_insert(jid, huc_ids, np_array, name_temp, section):
     except Exception as e:
         # Ignore mongo not working for now
         # TODO: Add proper identification of Mongo DB issues
-        print "MongoDB not connected for Section %s: %s" % (section, e)
+        print "MongoDB not connected for Section {0!s}: {1!s}".format(section, e)
 
 
 def create_huc_ids_list(np_array_huc_ids):

--- a/REST_UBER/sam_rest/sam_input_generator.py
+++ b/REST_UBER/sam_rest/sam_input_generator.py
@@ -447,146 +447,146 @@ def generate_sam_input_file(args, sam_input_file_path):
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Simulation Start Day Index \n" % inputs['sim_date_start_index'])
+        myfile.write("{0!s} !Simulation Start Day Index \n".format(inputs['sim_date_start_index']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Start Julian Day \n" % inputs['sim_date_start_since1900'])
+        myfile.write("{0!s} !Start Julian Day \n".format(inputs['sim_date_start_since1900']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !End Julian Day \n" % inputs['sim_date_end_since1900'])
+        myfile.write("{0!s} !End Julian Day \n".format(inputs['sim_date_end_since1900']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !First year \n" % inputs['sim_date_1st_year'])
+        myfile.write("{0!s} !First year \n".format(inputs['sim_date_1st_year']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !First mth \n" % inputs['sim_date_1st_month'])
+        myfile.write("{0!s} !First mth \n".format(inputs['sim_date_1st_month']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !First day \n" % inputs['sim_date_1st_day'])
+        myfile.write("{0!s} !First day \n".format(inputs['sim_date_1st_day']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Last yr \n" % inputs['sim_date_last_year'])
+        myfile.write("{0!s} !Last yr \n".format(inputs['sim_date_last_year']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !num years \n" % inputs['sim_no_of_years'])
+        myfile.write("{0!s} !num years \n".format(inputs['sim_no_of_years']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Total Number of Simulation Days \n" % inputs['sim_no_of_days'])
+        myfile.write("{0!s} !Total Number of Simulation Days \n".format(inputs['sim_no_of_days']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s \n" % ' '.join(map(str, inputs[
-            'sim_day_index_list'])))  # Map the list items to strings and join them together with " " (space); this prints list of strings without quotes around each list item
+        myfile.write("{0!s} \n".format(' '.join(map(str, inputs[
+            'sim_day_index_list']))))  # Map the list items to strings and join them together with " " (space); this prints list of strings without quotes around each list item
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s \n" % ' '.join(map(str, inputs[
-            'sim_day_date_list'])))  # Map the list items to strings and join them together with " " (space); this prints list of strings without quotes around each list item
+        myfile.write("{0!s} \n".format(' '.join(map(str, inputs[
+            'sim_day_date_list']))))  # Map the list items to strings and join them together with " " (space); this prints list of strings without quotes around each list item
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Chemical \n" % inputs['chemical_name'])
+        myfile.write("{0!s} !Chemical \n".format(inputs['chemical_name']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Number of Crops \n" % inputs['crop_number'])
+        myfile.write("{0!s} !Number of Crops \n".format(inputs['crop_number']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Crop IDs \n" % ' '.join(map(str, inputs['crop_list_no'])))
+        myfile.write("{0!s} !Crop IDs \n".format(' '.join(map(str, inputs['crop_list_no']))))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s. !Koc or Kd \n" % inputs['koc'])
+        myfile.write("{0!s}. !Koc or Kd \n".format(inputs['koc']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !1=Koc,2=Kd \n" % inputs['coefficient'])
+        myfile.write("{0!s} !1=Koc,2=Kd \n".format(inputs['coefficient']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s. !Soil Half Life \n" % inputs['soil_metabolism_hl'])
+        myfile.write("{0!s}. !Soil Half Life \n".format(inputs['soil_metabolism_hl']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Total Number of Apps \n" % inputs['total_no_of_apps'])
-    except Exception, e:
-        print str(e)
-        myfile.write(' ---ERROR--- \n')
-
-    try:
-        myfile.write("%s !Application num_record \n" % ' '.join(map(str, inputs['app_num_record'])))
-    except Exception, e:
-        print str(e)
-        myfile.write(' ---ERROR--- \n')
-    try:
-        myfile.write("%s !Application Julian dates \n" % ' '.join(map(str, inputs['app_record_day_since_1900'])))
-    except Exception, e:
-        print str(e)
-        myfile.write(' ---ERROR--- \n')
-    try:
-        myfile.write("%s !App mass kg/ha \n" % ' '.join(map(str, inputs['app_rate'])))
-    except Exception, e:
-        print str(e)
-        myfile.write(' ---ERROR--- \n')
-    try:
-        myfile.write("%s !App Method \n" % ' '.join(map(str, inputs['app_method'])))
+        myfile.write("{0!s} !Total Number of Apps \n".format(inputs['total_no_of_apps']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
 
     try:
-        myfile.write("%s !Output type (1=Daily,2=TimeAvg) \n" % inputs['output_type'])
+        myfile.write("{0!s} !Application num_record \n".format(' '.join(map(str, inputs['app_num_record']))))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Averaging period (days) \n" % inputs['output_avg_days'])
+        myfile.write("{0!s} !Application Julian dates \n".format(' '.join(map(str, inputs['app_record_day_since_1900']))))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Time-Avg Output Type (1=AvgConcs, 2=ToxExceed) \n" % inputs['output_time_avg_option'])
+        myfile.write("{0!s} !App mass kg/ha \n".format(' '.join(map(str, inputs['app_rate']))))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Time-Avg Conc Options Selected \n" % inputs['output_time_avg_conc'])
+        myfile.write("{0!s} !App Method \n".format(' '.join(map(str, inputs['app_method']))))
+    except Exception, e:
+        print str(e)
+        myfile.write(' ---ERROR--- \n')
+
+    try:
+        myfile.write("{0!s} !Output type (1=Daily,2=TimeAvg) \n".format(inputs['output_type']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Threshold(ug/L) \n" % inputs['output_tox_value'])
+        myfile.write("{0!s} !Averaging period (days) \n".format(inputs['output_avg_days']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')
     try:
-        myfile.write("%s !Threshold Options Selected \n" % inputs['output_tox_thres_exceed'])
+        myfile.write("{0!s} !Time-Avg Output Type (1=AvgConcs, 2=ToxExceed) \n".format(inputs['output_time_avg_option']))
+    except Exception, e:
+        print str(e)
+        myfile.write(' ---ERROR--- \n')
+    try:
+        myfile.write("{0!s} !Time-Avg Conc Options Selected \n".format(inputs['output_time_avg_conc']))
+    except Exception, e:
+        print str(e)
+        myfile.write(' ---ERROR--- \n')
+    try:
+        myfile.write("{0!s} !Threshold(ug/L) \n".format(inputs['output_tox_value']))
+    except Exception, e:
+        print str(e)
+        myfile.write(' ---ERROR--- \n')
+    try:
+        myfile.write("{0!s} !Threshold Options Selected \n".format(inputs['output_tox_thres_exceed']))
     except Exception, e:
         print str(e)
         myfile.write(' ---ERROR--- \n')

--- a/REST_UBER/sam_rest/sam_multiprocessing.py
+++ b/REST_UBER/sam_rest/sam_multiprocessing.py
@@ -20,8 +20,7 @@ def timeit(method):
         result = method(*args, **kw)
         te = time.time()
 
-        print '%s: Time start = %s, Time end = %s: %2.2f sec' % \
-              (args[0], ts, te, te-ts)
+        print '{0!s}: Time start = {1!s}, Time end = {2!s}: {3:2.2f} sec'.format(args[0], ts, te, te-ts)
         return result
 
     return timed
@@ -43,7 +42,7 @@ def multiprocessing_setup():
             nproc = 16
     except AttributeError:
         pass
-    print "max_workers=%s" % nproc
+    print "max_workers={0!s}".format(nproc)
     return Pool(max_workers=nproc)  # Set number of workers to equal the number of processors available on machine
 
 
@@ -83,7 +82,7 @@ class SamModelCaller(object):
         try:
             self.number_of_rows_list = self.split_csv()
         except Exception as e:
-            print "Split CSV failed: %s \n Using defaults for %s number of processes" % (e, self.no_of_processes)
+            print "Split CSV failed: {0!s} \n Using defaults for {1!s} number of processes".format(e, self.no_of_processes)
 
             # Below are defaults for a set number of processes for Ohio River Valley (HUC12) Region only
             if self.no_of_processes == 1:
@@ -117,7 +116,7 @@ class SamModelCaller(object):
                     153, 153, 153, 153, 153, 153, 153, 153, 153, 153, 153, 153, 153, 153, 153, 167
                 ]
 
-        print 'Started running SAM @ %s' % time.time()
+        print 'Started running SAM @ {0!s}'.format(time.time())
         for x in range(self.no_of_processes):  # Loop over all the 'no_of_processes' to fill the process
             pool.submit(
                 daily_conc_callable,
@@ -272,9 +271,9 @@ def main():
     else:
         sam = SamModelCaller(jid, name_temp)
 
-    print "JID = %s" % sam.jid
-    print "name_temp = %s" % sam.name_temp
-    print "no_of_processes = %s" % sam.no_of_processes
+    print "JID = {0!s}".format(sam.jid)
+    print "name_temp = {0!s}".format(sam.name_temp)
+    print "no_of_processes = {0!s}".format(sam.no_of_processes)
     sam.sam_multiprocessing()
 
 

--- a/REST_UBER/sam_rest/sam_rest_model.py
+++ b/REST_UBER/sam_rest/sam_rest_model.py
@@ -255,8 +255,8 @@ def callback_avg(temp_sam_run_path, jid, run_type, no_of_processes, args, sectio
 
             sam_db.update_mongo(temp_sam_run_path, jid, run_type, args, section, huc_output)
 
-            logging.info("jid = %s" % jid)
-            logging.info("run_type = %s" % run_type)
+            logging.info("jid = {0!s}".format(jid))
+            logging.info("run_type = {0!s}".format(run_type))
             logging.info("Last SuperPRZMpesticide process completed")
 
             # Remove temporary SAM run directory upon completion

--- a/REST_UBER/swagger_ui.py
+++ b/REST_UBER/swagger_ui.py
@@ -190,7 +190,7 @@ class OperationResponses(object):
         }
 
         if not self.valid_code(str(return_code)):
-            raise ValueError('Return status code must be: %s' % self.codes.keys())
+            raise ValueError('Return status code must be: {0!s}'.format(self.codes.keys()))
 
         if schema is None:
             self.schema = {

--- a/flask_cgi.py
+++ b/flask_cgi.py
@@ -57,7 +57,7 @@ _NO_MODEL_ERROR = "{} model is not available through the REST API"
 # TODO: Generic API endpoint (TEMPORARY, remove once all endpoints are explicitly stated)
 class ModelCaller(Resource):
     def get(self, model, jid):
-        return {'result': 'model=%s, jid=%s' % (model, jid)}
+        return {'result': 'model={0!s}, jid={1!s}'.format(model, jid)}
 
     def post(self, model, jid):
         # TODO: Remove the YAML part of this docstring
@@ -146,7 +146,7 @@ def therps_rest(jid):
     all_result = {}
     try:
         for k, v in request.json.iteritems():
-            exec '%s = v' % k
+            exec '{0!s} = v'.format(k)
         all_result.setdefault(jid, {}).setdefault('status', 'none')
         from therps import therps
         result = therps.therps(chem_name, use, formu_name, a_i, h_l, n_a, i_a, a_r, avian_ld50,
@@ -176,7 +176,7 @@ def kabam_rest(jid):
     all_result = {}
     try:
         for k, v in request.json.iteritems():
-            exec '%s = v' % k
+            exec '{0!s} = v'.format(k)
         all_result.setdefault(jid, {}).setdefault('status', 'none')
         from kabam import kabam
         result = kabam.kabam(chemical_name, l_kow, k_oc, c_wdp, water_column_EEC, c_wto,
@@ -349,7 +349,7 @@ def ore_rest_category_query():
 
     query = {}
     for k, v in request.json.iteritems():
-        exec "query['%s'] = v" % k
+        exec "query['{0!s}'] = v".format(k)
         # print k, v
 
     result = ore_db.oreWorkerActivities(query)

--- a/uber_swagger.py
+++ b/uber_swagger.py
@@ -80,7 +80,7 @@ def swagger(app):
         # Rule = endpoint URL relative to hostname; needs to have special characters escaped to be defaultdict key
         rule = str(rule)
         for arg in re.findall('(<(.*?\:)?(.*?)>)', rule):
-            rule = rule.replace(arg[0], '{%s}' % arg[2])
+            rule = rule.replace(arg[0], '{{{0!s}}}'.format(arg[2]))
 
         # For each Rule (endpoint) iterate over its HTTP methods (e.g. POST, GET, PUT, etc...)
         for http_method, handler_method in methods.items():


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:puruckertom:ubertool_ecorest?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:puruckertom:ubertool_ecorest?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)